### PR TITLE
Added example simpleapp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "examples/simpleapp"]
+	path = examples/simpleapp
+	url = https://github.com/butchmarshall/ruby-jive-sdk-example-simpleapp


### PR DESCRIPTION
The reference SDK simpleapp in a Rails app.

Includes several dependency Rails engines and Ruby gems that implement the core Jive functionality.

Still work to do, but it handles add-on registration and serving the opensocial xml.

Not sure if this is what you're looking for in this repo or if this is better suited for the jive-sdk-ruby repo?
